### PR TITLE
Added fix for Jsoncpp linker error on Arch based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,8 @@ You need the server started too. For that go to https://github.com/Jachdich/plan
 
 ### Linker error mentioning jsoncpp
 
-Ugh IDK how to fix this but you might have jsoncpp installed to a different location. It needs to be in `/usr/include/jsoncpp/json/` (or equivilent `include` directory). Some installs omit the final `json` which can break things, if that's the case for your install just `mkdir /tmp/json && mv /usr/include/jsoncpp/* /tmp/json && mv /tmp/json /usr/include/jsoncpp` or something else if your install is weird.
+You might have jsoncpp installed to a different location. It needs to be in `/usr/include/jsoncpp/json/` (or equivilent `include` directory). Some installs omit the final `json` which can break things, if that's the case for your install just `mkdir /tmp/json && mv /usr/include/jsoncpp/* /tmp/json && mv /tmp/json /usr/include/jsoncpp` or something else if your install is weird.
+
+A fix for Arch based distros:
+mkdir -p /usr/include/jsoncpp
+cp -r /usr/include/json /usr/include/jsoncpp


### PR DESCRIPTION
On Arch based distros jsoncpp is installed at /usr/include/json